### PR TITLE
Pass `flags` though to the PromptGui.

### DIFF
--- a/src/Common/Net/WindowsNonInteractiveCredentialProvider.cs
+++ b/src/Common/Net/WindowsNonInteractiveCredentialProvider.cs
@@ -23,7 +23,7 @@ public class WindowsNonInteractiveCredentialProvider : WindowsCredentialProvider
         }
 
         return WindowsCredentials.IsCredentialStored(target)
-            ? WindowsCredentials.PromptGui(target, WindowsCredentialsFlags.None)
+            ? WindowsCredentials.PromptGui(target, flags)
             : null;
     }
 }


### PR DESCRIPTION
By passing the flags through the calling application will retrieve the credential as expected as opposed to the library assuming a credential type of DOMAIN.

#103 